### PR TITLE
Implement basic feature to mount modular uenvs from the json description.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ barkeep_dep = declare_dependency(
 lib_src = [
         'src/site/site.cpp',
         'src/uenv/env.cpp',
+        'src/uenv/modular_env.cpp',
         'src/uenv/log.cpp',
         'src/uenv/meta.cpp',
         'src/uenv/oras.cpp',

--- a/src/cli/run.cpp
+++ b/src/cli/run.cpp
@@ -67,6 +67,11 @@ You need to finish the current session by typing 'exit' or hitting '<ctrl-d>'.)"
     for (auto e : env->uenvs) {
         commands.push_back(fmt::format("{}:{}", e.second.sqfs_path.string(),
                                        e.second.mount_path));
+        // sub-images
+        for (auto [sqfs, mnt] : e.second.sub_images) {
+            commands.push_back(
+                fmt::format("{}:{}", sqfs.string(), mnt.string()));
+        }
     }
 
     commands.push_back("--");

--- a/src/cli/start.cpp
+++ b/src/cli/start.cpp
@@ -112,7 +112,8 @@ will not work, because it starts a new interactive shell.)",
                                        e.second.mount_path));
         // sub-images
         for (auto [sqfs, mnt] : e.second.sub_images) {
-          commands.push_back(fmt::format("{}:{}", sqfs.string(), mnt.string()));
+            commands.push_back(
+                fmt::format("{}:{}", sqfs.string(), mnt.string()));
         }
     }
 

--- a/src/cli/start.cpp
+++ b/src/cli/start.cpp
@@ -110,6 +110,10 @@ will not work, because it starts a new interactive shell.)",
     for (auto e : env->uenvs) {
         commands.push_back(fmt::format("{}:{}", e.second.sqfs_path.string(),
                                        e.second.mount_path));
+        // sub-images
+        for (auto [sqfs, mnt] : e.second.sub_images) {
+          commands.push_back(fmt::format("{}:{}", sqfs.string(), mnt.string()));
+        }
     }
 
     // find the current shell (zsh, bash, etc)

--- a/src/uenv/env.cpp
+++ b/src/uenv/env.cpp
@@ -126,7 +126,8 @@ concretise_env(const std::string& uenv_args,
         // determine the sqfs_path
         fs::path sqfs_path;
         // dependent images
-        std::vector<std::tuple<std::filesystem::path, std::filesystem::path>> sub_images;
+        std::vector<std::tuple<std::filesystem::path, std::filesystem::path>>
+            sub_images;
         // if a label was used to describe the uenv (e.g. "prgenv-gnu/24.7"
         // it has to be looked up in a repo.
         if (auto label = desc.label()) {
@@ -180,7 +181,7 @@ concretise_env(const std::string& uenv_args,
                 // NOTE: we ignore mount_path and read it from the sqfs file
                 auto menv = read_modular_env(sqfs_path, *repo_arg);
                 if (!menv) {
-                  return unexpected(menv.error());
+                    return unexpected(menv.error());
                 }
                 sqfs_path = menv.value().sqfs_path;
                 sub_images = menv.value().sub_images;

--- a/src/uenv/modular_env.cpp
+++ b/src/uenv/modular_env.cpp
@@ -23,7 +23,7 @@ read_modular_env(const std::filesystem::path& modular_uenv_json_path,
                         modular_uenv_json_path.string(), e.what()));
     }
 
-    if (!data.contains("root-image")) {
+    if (!data.contains("root")) {
         return util::unexpected(
             fmt::format("error {} doesn't specify the root-image",
                         modular_uenv_json_path.string()));
@@ -38,9 +38,9 @@ read_modular_env(const std::filesystem::path& modular_uenv_json_path,
     std::vector<std::tuple<std::filesystem::path, std::filesystem::path>>
         sub_images;
     std::filesystem::path sqfs_path =
-        data["root-image"]["image"]["file"].get<std::string>();
+        data["root"]["image"]["file"].get<std::string>();
     std::filesystem::path mount_path =
-        data["root-image"]["image"]["prefix_path"].get<std::string>();
+        data["root"]["image"]["prefix_path"].get<std::string>();
 
     // GPU image if present
     if (data.contains("gpu")) {

--- a/src/uenv/modular_env.cpp
+++ b/src/uenv/modular_env.cpp
@@ -44,8 +44,8 @@ read_modular_env(const std::filesystem::path& modular_uenv_json_path,
 
     // GPU image if present
     if (data.contains("gpu")) {
-        std::filesystem::path image = data["gpu"]["file"];
-        std::filesystem::path mount = data["gpu"]["prefix_path"];
+        std::filesystem::path image = data["gpu"]["image"]["file"];
+        std::filesystem::path mount = data["gpu"]["image"]["prefix_path"];
         sub_images.push_back(std::make_tuple(image, mount));
     }
 

--- a/src/uenv/modular_env.cpp
+++ b/src/uenv/modular_env.cpp
@@ -1,0 +1,66 @@
+#include "modular_env.hpp"
+#include <tuple>
+#include <util/expected.h>
+#include <exception>
+#include <fstream>
+#include <nlohmann/json.hpp>
+#include <uenv/repository.h>
+
+namespace uenv {
+
+util::expected<modular_env_paths, std::string>
+read_modular_env(const std::filesystem::path& modular_uenv_json_path,
+                       std::optional<std::filesystem::path> repo_arg) {
+
+    using json = nlohmann::json;
+    std::ifstream f(modular_uenv_json_path.c_str());
+    json data;
+    try {
+        data = json::parse(f);
+    } catch (std::exception& e) {
+        return util::unexpected(
+            fmt::format("error modular uenv json file {}: {}",
+                        modular_uenv_json_path.string(), e.what()));
+    }
+
+    if (!data.contains("root-image")) {
+        return util::unexpected(
+            fmt::format("error {} doesn't specify the root-image",
+                        modular_uenv_json_path.string()));
+    }
+
+    auto store = uenv::open_repository(*repo_arg);
+    if (!store) {
+        return util::unexpected(
+            fmt::format("unable to open repo: {}", store.error()));
+    }
+
+    std::vector<std::tuple<std::filesystem::path, std::filesystem::path>>
+        sub_images;
+    std::filesystem::path sqfs_path =
+        data["root-image"]["file"].get<std::string>();
+    std::filesystem::path mount_path =
+        data["root-image"]["prefix_path"].get<std::string>();
+
+    // GPU image if present
+    if (data.contains("gpu")) {
+        std::filesystem::path image = data["gpu"]["file"];
+        std::filesystem::path mount = data["gpu"]["prefix_path"];
+        sub_images.push_back(std::make_tuple(image, mount));
+    }
+
+    if (data.contains("compilers")) {
+      for(auto entry: data["compilers"]) {
+        auto mount = entry["image"]["prefix_path"];
+        auto sqfs = entry["image"]["file"];
+        sub_images.push_back(std::make_tuple(sqfs,mount));
+      }
+    }
+
+    return modular_env_paths{
+      .sqfs_path = sqfs_path,
+      .mount_path = mount_path,
+      .sub_images = sub_images};
+}
+
+} // namespace uenv

--- a/src/uenv/modular_env.cpp
+++ b/src/uenv/modular_env.cpp
@@ -1,16 +1,16 @@
 #include "modular_env.hpp"
-#include <tuple>
-#include <util/expected.h>
 #include <exception>
 #include <fstream>
 #include <nlohmann/json.hpp>
+#include <tuple>
 #include <uenv/repository.h>
+#include <util/expected.h>
 
 namespace uenv {
 
 util::expected<modular_env_paths, std::string>
 read_modular_env(const std::filesystem::path& modular_uenv_json_path,
-                       std::optional<std::filesystem::path> repo_arg) {
+                 std::optional<std::filesystem::path> repo_arg) {
 
     using json = nlohmann::json;
     std::ifstream f(modular_uenv_json_path.c_str());
@@ -50,17 +50,16 @@ read_modular_env(const std::filesystem::path& modular_uenv_json_path,
     }
 
     if (data.contains("compilers")) {
-      for(auto entry: data["compilers"]) {
-        auto mount = entry["image"]["prefix_path"];
-        auto sqfs = entry["image"]["file"];
-        sub_images.push_back(std::make_tuple(sqfs,mount));
-      }
+        for (auto entry : data["compilers"]) {
+            auto mount = entry["image"]["prefix_path"];
+            auto sqfs = entry["image"]["file"];
+            sub_images.push_back(std::make_tuple(sqfs, mount));
+        }
     }
 
-    return modular_env_paths{
-      .sqfs_path = sqfs_path,
-      .mount_path = mount_path,
-      .sub_images = sub_images};
+    return modular_env_paths{.sqfs_path = sqfs_path,
+                             .mount_path = mount_path,
+                             .sub_images = sub_images};
 }
 
 } // namespace uenv

--- a/src/uenv/modular_env.cpp
+++ b/src/uenv/modular_env.cpp
@@ -38,9 +38,9 @@ read_modular_env(const std::filesystem::path& modular_uenv_json_path,
     std::vector<std::tuple<std::filesystem::path, std::filesystem::path>>
         sub_images;
     std::filesystem::path sqfs_path =
-        data["root-image"]["file"].get<std::string>();
+        data["root-image"]["image"]["file"].get<std::string>();
     std::filesystem::path mount_path =
-        data["root-image"]["prefix_path"].get<std::string>();
+        data["root-image"]["image"]["prefix_path"].get<std::string>();
 
     // GPU image if present
     if (data.contains("gpu")) {

--- a/src/uenv/modular_env.hpp
+++ b/src/uenv/modular_env.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <optional>
-#include <filesystem>
-#include <util/expected.h>
 #include "uenv/uenv.h"
+#include <filesystem>
+#include <optional>
+#include <util/expected.h>
 
 namespace uenv {
 
-
 struct modular_env_paths {
-  std::filesystem::path sqfs_path;
-  std::filesystem::path mount_path;
-  std::vector<std::tuple<std::filesystem::path, std::filesystem::path>> sub_images;
+    std::filesystem::path sqfs_path;
+    std::filesystem::path mount_path;
+    std::vector<std::tuple<std::filesystem::path, std::filesystem::path>>
+        sub_images;
 };
 
 util::expected<modular_env_paths, std::string>

--- a/src/uenv/modular_env.hpp
+++ b/src/uenv/modular_env.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <optional>
+#include <filesystem>
+#include <util/expected.h>
+#include "uenv/uenv.h"
+
+namespace uenv {
+
+
+struct modular_env_paths {
+  std::filesystem::path sqfs_path;
+  std::filesystem::path mount_path;
+  std::vector<std::tuple<std::filesystem::path, std::filesystem::path>> sub_images;
+};
+
+util::expected<modular_env_paths, std::string>
+read_modular_env(const std::filesystem::path&,
+                 std::optional<std::filesystem::path>);
+
+} // namespace uenv

--- a/src/uenv/uenv.h
+++ b/src/uenv/uenv.h
@@ -147,6 +147,9 @@ struct concrete_uenv {
     std::filesystem::path mount_path;
     /// the path of the squashfs image to be mounted
     std::filesystem::path sqfs_path;
+    /// subordinate images tuple(sqfs path, mount point)
+    std::vector<std::tuple<std::filesystem::path, std::filesystem::path>>
+        sub_images;
     /// the path of the meta data - not set if no meta data path was found
     std::optional<std::filesystem::path> meta_path;
 


### PR DESCRIPTION
- mount modular uenv from json description: https://github.com/eth-cscs/stackinator/blob/feat/modular-sqfs/stackinator/schema/base-uenv.json
 - an image is described as 
   ```json
          "image": {
            "name": "osu-micro-benchmarks@daint",
            "prefix_path": "/user-environment/",
            "file": "/capstor/scratch/.../osu-daint.sqfs",
            "sha256": "c4e990bcbdf261ab627143596a811ca239637d861b3e6b3e5b69f421dc3830d1"
        }
   ```
  Currently only `file` and `prefix_path` are used. Idea is to use `sha256` once the base images are in the uenv repo.
- TODO: if the base uenvs contains the meta directory, `uenv status` will discover the views in the base uenvs (since they appear in UENV_MOUNT_LIST). Either remove them from UENV_MOUNT_LIST or build the base uenvs without the env.json.