### PR TITLE
configure slurm version in meson

### DIFF
--- a/meson-scripts/get-slurm.sh
+++ b/meson-scripts/get-slurm.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+major="$1"
+minor="$2"
+patch="$3"
+destination="$4"
+
+# create version in yy.mm.p form (i.e. with the month padded with 0 to always be 2 digits)
+slurm_version=$(printf '%d.%02d.%d' $major $minor $patch)
+# The slurm version is hardcoded in the header in hexadecimal format, [major][minor][patch] (two digits each)
+slurm_hex_version=$(printf '0x%02x%02x%02x' $major $minor $patch)
+
+url=https://download.schedmd.com/slurm/slurm-${slurm_version}.tar.bz2
+
+slurm_version_path="slurm-${slurm_version}"
+slurm_download_path="$(pwd)/${slurm_version_path}/slurm"
+curl --silent --location $url | tar -xj "${slurm_version_path}/slurm/spank.h" \
+                       "${slurm_version_path}/slurm/slurm_errno.h" \
+                       "${slurm_version_path}/slurm/slurm_version.h.in"
+
+# Create slurm_version.h from .in
+sed "s/^#undef SLURM_VERSION_NUMBER.*/#define SLURM_VERSION_NUMBER $slurm_hex_version/" \
+    "${slurm_download_path}/slurm_version.h.in" > "$destination/slurm_version.h"
+cp  "${slurm_download_path}/spank.h"              "${destination}/spank.h"
+cp  "${slurm_download_path}/slurm_errno.h"        "${destination}/slurm_errno.h"

--- a/meson.build
+++ b/meson.build
@@ -137,6 +137,7 @@ if uenv_cli
 endif
 
 if uenv_slurm_plugin
+    slurm_version = get_option('slurm_version')
     subdir('src/slurm')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,3 +5,5 @@ option('cli', type: 'boolean', value: true)
 option('squashfs_mount', type: 'boolean', value: false)
 
 option('oras_version', type: 'string', value: '1.2.0')
+#option('slurm_version', type: 'string', value: '24.05.0')
+option('slurm_version', type: 'string', value: '0.00.0')

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -16,6 +16,8 @@ Options:
 # A temporary variable to hold the output of `getopt`
 TEMP=$(getopt -o r:h --long ref:,remote:,help,slurm-version: -- "$@")
 
+# default Slurm version is 0 -> use system slurm
+slurm_version="00.00.0"
 remote=https://github.com/eth-cscs/uenv2
 
 # If getopt has reported an error, exit script with an error
@@ -26,9 +28,6 @@ if [ $? != 0 ]; then
 fi
 
 eval set -- "$TEMP"
-
-# default Slurm version is 0 -> use system slurm
-slurm_version="00.00.0"
 
 # Now go through all the options
 while true; do

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -20,44 +20,44 @@ remote=https://github.com/eth-cscs/uenv2
 
 # If getopt has reported an error, exit script with an error
 if [ $? != 0 ]; then
-	# echo 'Error parsing options' >&2
-	echo "${usage}" >&2
-	exit 1
+    # echo 'Error parsing options' >&2
+    echo "${usage}" >&2
+    exit 1
 fi
 
 eval set -- "$TEMP"
 
 # Now go through all the options
 while true; do
-	case "$1" in
-	-r | --ref)
-		shift
-		git_ref="$1"
-		shift
-		;;
-	--remote)
-		shift
-		remote="$1"
-		;;
-	--slurm-version)
-		shift
-		slurm_version="$1"
-		shift
-		;;
-	-h | --help)
-		shift
-		echo "${usage}"
-		exit 1
-		;;
-	--)
-		shift
-		break
-		;;
-	*)
-		echo "Internal error! $1"
-		exit 1
-		;;
-	esac
+    case "$1" in
+    -r | --ref)
+        shift
+        git_ref="$1"
+        shift
+        ;;
+    --remote)
+        shift
+        remote="$1"
+        ;;
+    --slurm-version)
+        shift
+        slurm_version="$1"
+        shift
+        ;;
+    -h | --help)
+        shift
+        echo "${usage}"
+        exit 1
+        ;;
+    --)
+        shift
+        break
+        ;;
+    *)
+        echo "Internal error! $1"
+        exit 1
+        ;;
+    esac
 done
 
 _scriptdir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
@@ -65,46 +65,46 @@ _scriptdir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 wd=$(mktemp -d)
 
 if [ -z ${git_ref+x} ]; then
-	>&2 echo "-r,--ref must be passed."
-	exit 1
+    >&2 echo "-r,--ref must be passed."
+    exit 1
 fi
 
 (
-	cd $wd || exit 1
-	git clone -b $git_ref $remote src
+    cd $wd || exit 1
+    git clone -b $git_ref $remote src
 
-	if [ ! -z ${slurm_version+x} ]; then
-		>&2 echo "download slurm headers"
-		IFS='.' read -r major minor patch <<<"$slurm_version"
-		curl -L https://download.schedmd.com/slurm/slurm-${slurm_version}.tar.bz2 |
-			tar -xj \
-				slurm-${slurm_version}/slurm/spank.h \
-				slurm-${slurm_version}/slurm/slurm_errno.h \
-				slurm-${slurm_version}/slurm/slurm_version.h.in
+    if [ ! -z ${slurm_version+x} ]; then
+        >&2 echo "download slurm headers"
+        IFS='.' read -r major minor patch <<<"$slurm_version"
+        curl -L https://download.schedmd.com/slurm/slurm-${slurm_version}.tar.bz2 |
+            tar -xj \
+                slurm-${slurm_version}/slurm/spank.h \
+                slurm-${slurm_version}/slurm/slurm_errno.h \
+                slurm-${slurm_version}/slurm/slurm_version.h.in
 
-		# The slurm version is hardcoded in the header in hexadecimal format, [major][minor][patch] (two digits each)
-		SLURM_VERSION_NUMBER=$(printf '0x%02x%02x%02x' $major $minor $patch)
-		echo "SLURM_VERSION_NUMBER: ${SLURM_VERSION_NUMBER}"
+        # The slurm version is hardcoded in the header in hexadecimal format, [major][minor][patch] (two digits each)
+        SLURM_VERSION_NUMBER=$(printf '0x%02x%02x%02x' $major $minor $patch)
+        echo "SLURM_VERSION_NUMBER: ${SLURM_VERSION_NUMBER}"
 
-		# Create slurm_version.h from .in
-		sed "s/^#undef SLURM_VERSION_NUMBER.*/#define SLURM_VERSION_NUMBER $SLURM_VERSION_NUMBER/" \
-			slurm-${slurm_version}/slurm/slurm_version.h.in >slurm-${slurm_version}/slurm/slurm_version.h
-		INCLUDE="-I$(realpath slurm-${slurm_version})"
-	else
-		>&2 echo "attempt to use slurm headers from the system"
-		INCLUDE=""
-	fi
+        # Create slurm_version.h from .in
+        sed "s/^#undef SLURM_VERSION_NUMBER.*/#define SLURM_VERSION_NUMBER $SLURM_VERSION_NUMBER/" \
+            slurm-${slurm_version}/slurm/slurm_version.h.in >slurm-${slurm_version}/slurm/slurm_version.h
+        INCLUDE="-I$(realpath slurm-${slurm_version})"
+    else
+        >&2 echo "attempt to use slurm headers from the system"
+        INCLUDE=""
+    fi
 
-	FLAGS="-O2 -fmessage-length=0 -D_FORTIFY_SOURCE=2 -fstack-protector"
-	# Build RPM
-	mkdir rpmbuild
-	LDFLAGS="-Wl,--disable-new-dtags -Wl,-rpath,/lib64 -Wl,-rpath,/usr/lib64" \
-		CXXFLAGS="$INCLUDE $FLAGS" \
-		CFLAGS="$INCLUDE $FLAGS" \
-		${_scriptdir}/rpmbuild-wrapper.sh --slurm-version=$slurm_version ./src ./rpmbuild \
-		2>${_scriptdir}/stderr.log 1>${_scriptdir}/stdout.log
+    FLAGS="-O2 -fmessage-length=0 -D_FORTIFY_SOURCE=2 -fstack-protector"
+    # Build RPM
+    mkdir rpmbuild
+    LDFLAGS="-Wl,--disable-new-dtags -Wl,-rpath,/lib64 -Wl,-rpath,/usr/lib64" \
+        CXXFLAGS="$INCLUDE $FLAGS" \
+        CFLAGS="$INCLUDE $FLAGS" \
+        ${_scriptdir}/rpmbuild-wrapper.sh --slurm-version=$slurm_version ./src ./rpmbuild \
+        2>${_scriptdir}/stderr.log 1>${_scriptdir}/stdout.log
 
   set -x
-	find ./rpmbuild/RPMS -iname '*.rpm' -exec cp {} ${_scriptdir} \;
+    find ./rpmbuild/RPMS -iname '*.rpm' -exec cp {} ${_scriptdir} \;
   set +x
 )

--- a/packaging/macros/macros.meson
+++ b/packaging/macros/macros.meson
@@ -9,24 +9,25 @@
   FFLAGS="${FFLAGS:-%optflags}"; export FFLAGS; \
   FCFLAGS="${FCFLAGS:-%optflags}"; export FCFLAGS; \
   meson setup %{__sourcedir} %{__builddir}  \\\
-	--prefix=%{_prefix} \\\
-	--buildtype=release \\\
-	--bindir=%{_bindir} \\\
-	--sbindir=%{_sbindir} \\\
-	--libexecdir=/usr/libexec \\\
-	--libdir=%{_libdir} \\\
-	--localstatedir=%{_var} \\\
-	--sharedstatedir=%{_sharedstatedir} \\\
-	--includedir=%{_includedir} \\\
-	--datadir=%{_datadir} \\\
-	--sysconfdir=%{_sysconfdir} \\\
-	--mandir=%{_mandir} \\\
-	--infodir=%{_infodir} \\\
-	--localedir=%{_datadir}/locale \\\
-	-Dcli=true \\\
-	-Dslurm_plugin=true \\\
-  -Dsquashfs_mount=true \\\
-	%{nil}
+    --prefix=%{_prefix} \\\
+    --buildtype=release \\\
+    --bindir=%{_bindir} \\\
+    --sbindir=%{_sbindir} \\\
+    --libexecdir=/usr/libexec \\\
+    --libdir=%{_libdir} \\\
+    --localstatedir=%{_var} \\\
+    --sharedstatedir=%{_sharedstatedir} \\\
+    --includedir=%{_includedir} \\\
+    --datadir=%{_datadir} \\\
+    --sysconfdir=%{_sysconfdir} \\\
+    --mandir=%{_mandir} \\\
+    --infodir=%{_infodir} \\\
+    --localedir=%{_datadir}/locale \\\
+    -Dcli=true \\\
+    -Dslurm_plugin=true \\\
+    -Dsquashfs_mount=true \\\
+    -Dslurm_version=%{_slurm_version} \\\
+    %{nil}
 
 %meson_build \
 meson compile %_smp_mflags -C %{__builddir}

--- a/packaging/rpmbuild-wrapper.sh
+++ b/packaging/rpmbuild-wrapper.sh
@@ -114,7 +114,7 @@ tarball=uenv-"${SLURM_UENV_MOUNT_VERSION}".tar.gz
 
   if [ "${skip_bin}" -eq "0" ]; then
     # create binary rpm
-    rpmbuild -vv --nodeps --define "_topdir $(pwd)" \
+    rpmbuild -vv --nodeps --define "_topdir $(pwd)" --define "_slurm_version ${RPM_SLURM_VERSION}" \
              --rebuild SRPMS/uenv-*.src.rpm
   fi
 )

--- a/src/slurm/meson.build
+++ b/src/slurm/meson.build
@@ -5,11 +5,13 @@ configure_file(input : 'config.hpp.in',
                output : 'config.hpp',
                configuration : conf_data)
 
+subdir('slurm')
+
 module_src = ['plugin.cpp', 'mount_slurm.cpp']
 
 shared_module('slurm-uenv-mount',
               sources: module_src,
-              dependencies: uenv_dep,
+              dependencies: [uenv_dep, slurm_dep],
               cpp_args: ['-Wall', '-Wpedantic', '-Wextra'],
               install: true)
 

--- a/src/slurm/slurm/meson.build
+++ b/src/slurm/slurm/meson.build
@@ -1,0 +1,48 @@
+# Set up the external slurm dependency: slurm_dep
+#
+# To build a Slurm plugin we only require the following headers:
+#     slurm/slurm_version.h
+#     slurm/spank.h
+#     slurm/slurm_errno.h
+# By default the slurm_version is 0.0.0, which we interpret as "use the version
+# of Slurm installed on the system", i.e. slurm_dep will be an empty dependency.
+#
+# Otherwise, download the tar ball for the selected version of slurm and extract
+# only the required headers using the get-slurm.sh script.
+# The header files will be installed in the current path, which is added to the
+# include search path in the slurm_dep dependency.
+
+slurm_version_parts = slurm_version.split('.')
+if slurm_version_parts.length() != 3
+  error('slurm_version must be in major.minor.patch format')
+endif
+
+slurm_major = slurm_version_parts[0].to_int()
+slurm_minor = slurm_version_parts[1].to_int()
+slurm_patch = slurm_version_parts[2].to_int()
+
+# download the slurm source code if requested
+if slurm_major > 0
+  message('DOWNLOADING SLURM')
+  slurm_path   = meson.current_build_dir()
+  slurm_script = meson.project_source_root() +  '/meson-scripts/get-slurm.sh'
+  slurm_headers = custom_target(
+        'slurm-headers',
+        output: ['version.h', 'spank.h', 'slurm_errno.h'],
+        command: [slurm_script, slurm_major.to_string(),
+                  slurm_minor.to_string(), slurm_patch.to_string(), slurm_path],
+        install: false,
+        install_dir: get_option('libexecdir'),
+  )
+  slurm_inc = include_directories('..')
+  slurm_dep = declare_dependency(
+    include_directories: slurm_inc,
+    sources: slurm_headers,
+  )
+else
+  slurm_inc = include_directories()
+  slurm_dep = declare_dependency(
+    include_directories: slurm_inc,
+  )
+endif
+

--- a/src/slurm/slurm/meson.build
+++ b/src/slurm/slurm/meson.build
@@ -23,7 +23,6 @@ slurm_patch = slurm_version_parts[2].to_int()
 
 # download the slurm source code if requested
 if slurm_major > 0
-  message('DOWNLOADING SLURM')
   slurm_path   = meson.current_build_dir()
   slurm_script = meson.project_source_root() +  '/meson-scripts/get-slurm.sh'
   slurm_headers = custom_target(


### PR DESCRIPTION
Add `slurm_version` as a meson option.

If it is set, meson will download the slurm headers for the selected version when building the Slurm plugin.

Otherwise the version installed on the system will be used.