### PR TITLE
allow setting default system_name=*

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 ## 10.0.0
 
+- #147 [feature] support using '*' as cluster name in configuration files and --system flag
+- #145 [feature] move nearly all cscs-specific logic into configuration files
+- #144 [fix] fix latent bug parsing date strings
 - #143 [feature] improved bash completion for uenv labels and files
 - #142 [feature] use toml for configuration; support multiple repositories
 - #136 [feature] support for default views

--- a/src/slurm/elastic.cpp
+++ b/src/slurm/elastic.cpp
@@ -18,6 +18,7 @@
 #include <util/curl.h>
 #include <util/expected.h>
 #include <util/fs.h>
+#include <util/strings.h>
 
 namespace uenv {
 
@@ -48,14 +49,25 @@ slurm_elastic_payload(const std::vector<telemetry_data>& uenv_data,
             return util::unexpected{"SLURM_JOBID is not set"};
         }
 
-        // fields that can be "null" are set as empty strings.
-        // this is because elastic does not like the types of fields to differ
-        // over time, and setting an unset field to null would violate that.
-        // data["cluster"] = calling_env.get("CLUSTER_NAME").value_or("");
-        std::string cluster_name =
+        // determine the system name. We go out of our way to infer the cluster
+        // name from e.g. /etc/xthostname and SLURM_CLUSTER_NAME to best match
+        // the system name used by slurm, and to make it harder for users to
+        // spoof a cluster name.
+        //
+        // fields that can be "null" are set as empty
+        // strings. this is because elastic does not like the types of fields to
+        // differ over time, and setting an unset field to null would violate
+        // that.
+        std::string raw_cluster_name =
             util::read_single_line_file("/etc/xthostname")
                 .value_or(calling_env.get("SLURM_CLUSTER_NAME").value_or(""));
-        data["vcluster"] = parse_cluster_name(cluster_name).value_or("");
+
+        // strip prefixes like the "alps-" in "alps-daint"
+        std::string cluster_name = util::split(raw_cluster_name, '-').back();
+        // this looks a bit funny because parse_cluster_name returns
+        // expected<optional<string>>
+        data["vcluster"] =
+            parse_cluster_name(cluster_name).value_or("").value_or("");
         data["hostname"] =
             util::read_single_line_file("/etc/hostname")
                 .value_or(calling_env.get("HOSTNAME").value_or(""));

--- a/src/slurm/elastic.cpp
+++ b/src/slurm/elastic.cpp
@@ -51,19 +51,21 @@ slurm_elastic_payload(const std::vector<telemetry_data>& uenv_data,
 
         // determine the system name. We go out of our way to infer the cluster
         // name from e.g. /etc/xthostname and SLURM_CLUSTER_NAME to best match
-        // the system name used by slurm, and to make it harder for users to
-        // spoof a cluster name.
+        // the system name used by slurm, and to make it harder to accidentally
+        // or deliberately spoof a cluster name.
         //
-        // fields that can be "null" are set as empty
-        // strings. this is because elastic does not like the types of fields to
-        // differ over time, and setting an unset field to null would violate
-        // that.
-        std::string raw_cluster_name =
-            util::read_single_line_file("/etc/xthostname")
-                .value_or(calling_env.get("SLURM_CLUSTER_NAME").value_or(""));
+        // fields that can be "null" are set as empty strings. this is because
+        // elastic does not like the types of fields to differ over time, and
+        // setting an unset field to null would violate that.
+        const auto xthostname = util::read_single_line_file("/etc/xthostname");
+        std::string slurm_cluster_name =
+            calling_env.get("SLURM_CLUSTER_NAME").value_or("");
 
-        // strip prefixes like the "alps-" in "alps-daint"
-        std::string cluster_name = util::split(raw_cluster_name, '-').back();
+        std::string cluster_name =
+            xthostname
+                ? parse_xthostname(*xthostname).value_or(slurm_cluster_name)
+                : slurm_cluster_name;
+
         // this looks a bit funny because parse_cluster_name returns
         // expected<optional<string>>
         data["vcluster"] =

--- a/src/slurm/plugin.cpp
+++ b/src/slurm/plugin.cpp
@@ -31,7 +31,7 @@ extern "C" {
 namespace uenv {
 
 void set_log_level(const envvars::state& env) {
-    // use warn as the default log level
+    // disable logging by default
     auto log_level = spdlog::level::off;
     bool invalid_env = false;
 

--- a/src/uenv/parse.cpp
+++ b/src/uenv/parse.cpp
@@ -603,11 +603,36 @@ parse_cluster_name(lex::lexer& L) {
     return parse_string(L, "cluster", is_cluster_tok);
 }
 
+util::expected<std::string, parse_error> parse_xthostname(lex::lexer& L) {
+    auto name = parse_string(L, "cluster", is_cluster_tok);
+    if (name && L == lex::tok::dash) {
+        L.next();
+        return parse_string(L, "cluster", is_cluster_tok);
+    }
+    return name;
+}
+
 util::expected<std::optional<std::string>, parse_error>
 parse_cluster_name(const std::string& in) {
     const std::string sanitised = util::strip(in);
     auto L = lex::lexer(sanitised);
     const auto result = parse_cluster_name(L);
+    if (!result) {
+        return result;
+    }
+
+    if (const auto t = L.peek(); t.kind != lex::tok::end) {
+        return util::unexpected(parse_error{
+            L.string(), fmt::format("unexpected symbol '{}'", t.spelling), t});
+    }
+    return result;
+}
+
+util::expected<std::string, parse_error>
+parse_xthostname(const std::string& in) {
+    const std::string sanitised = util::strip(in);
+    auto L = lex::lexer(sanitised);
+    const auto result = parse_xthostname(L);
     if (!result) {
         return result;
     }

--- a/src/uenv/parse.cpp
+++ b/src/uenv/parse.cpp
@@ -594,9 +594,17 @@ bool is_cluster_tok(lex::tok t) {
 };
 
 util::expected<std::string, parse_error> parse_cluster_name(lex::lexer& L) {
+    // special case the wild card *
+    if (L == lex::tok::star) {
+        L.next();
+        if (L == lex::tok::end) {
+            return "*";
+        }
+        return util::unexpected(
+            parse_error{L.string(), "unexpected symbol '{}'", L.peek()});
+    }
     if (const auto namestr = parse_string(L, "cluster", is_cluster_tok)) {
-        // succesfully parsed a cluster name in the 'name' format, e.g. 'daint'
-        // or 'eiger'
+        // succesfully parsed a cluster name e.g. 'daint' or 'eiger'
         if (L == lex::tok::end) {
             return namestr;
         }
@@ -604,13 +612,9 @@ util::expected<std::string, parse_error> parse_cluster_name(lex::lexer& L) {
         // return the error
         return namestr;
     }
-    // there is more to process: expect a long name with a dash
-    if (L != lex::tok::dash) {
-        return util::unexpected(
-            parse_error{L.string(), "expected a '-'", L.peek()});
-    }
-    L.next();
-    return parse_string(L, "cluster", is_cluster_tok);
+
+    return util::unexpected(
+        parse_error{L.string(), "unexpected symvbol {}", L.peek()});
 }
 
 util::expected<std::string, parse_error>

--- a/src/uenv/parse.cpp
+++ b/src/uenv/parse.cpp
@@ -593,31 +593,17 @@ bool is_cluster_tok(lex::tok t) {
     return t == lex::tok::symbol || t == lex::tok::integer;
 };
 
-util::expected<std::string, parse_error> parse_cluster_name(lex::lexer& L) {
+util::expected<std::optional<std::string>, parse_error>
+parse_cluster_name(lex::lexer& L) {
     // special case the wild card *
     if (L == lex::tok::star) {
         L.next();
-        if (L == lex::tok::end) {
-            return "*";
-        }
-        return util::unexpected(
-            parse_error{L.string(), "unexpected symbol '{}'", L.peek()});
+        return std::nullopt;
     }
-    if (const auto namestr = parse_string(L, "cluster", is_cluster_tok)) {
-        // succesfully parsed a cluster name e.g. 'daint' or 'eiger'
-        if (L == lex::tok::end) {
-            return namestr;
-        }
-    } else {
-        // return the error
-        return namestr;
-    }
-
-    return util::unexpected(
-        parse_error{L.string(), "unexpected symvbol {}", L.peek()});
+    return parse_string(L, "cluster", is_cluster_tok);
 }
 
-util::expected<std::string, parse_error>
+util::expected<std::optional<std::string>, parse_error>
 parse_cluster_name(const std::string& in) {
     const std::string sanitised = util::strip(in);
     auto L = lex::lexer(sanitised);

--- a/src/uenv/parse.h
+++ b/src/uenv/parse.h
@@ -77,7 +77,7 @@ parse_registry_entry(const std::string& in);
 util::expected<config_line, parse_error>
 parse_config_line(const std::string& arg);
 
-util::expected<std::string, parse_error>
+util::expected<std::optional<std::string>, parse_error>
 parse_cluster_name(const std::string& in);
 
 util::expected<std::string, parse_error> parse_repo_name(const std::string& in);

--- a/src/uenv/parse.h
+++ b/src/uenv/parse.h
@@ -73,12 +73,15 @@ parse_uenv_nslabel(const std::string& in);
 util::expected<uenv_registry_entry, parse_error>
 parse_registry_entry(const std::string& in);
 
-// TODO: deprecate as soon as the old config file format is dropped
+// TODO: remove as soon as the old config file format is dropped
 util::expected<config_line, parse_error>
 parse_config_line(const std::string& arg);
 
 util::expected<std::optional<std::string>, parse_error>
 parse_cluster_name(const std::string& in);
+
+util::expected<std::string, parse_error>
+parse_xthostname(const std::string& in);
 
 util::expected<std::string, parse_error> parse_repo_name(const std::string& in);
 

--- a/src/uenv/repository.cpp
+++ b/src/uenv/repository.cpp
@@ -1152,6 +1152,11 @@ record_set::const_iterator record_set::cend() const {
 
 uenv_label apply_system(uenv_label label,
                         std::optional<std::string> system_name) {
+    // convert the star wildcard into nullopt
+    if (system_name && system_name.value() == "*") {
+        system_name = std::nullopt;
+    }
+
     if (!label.system) {
         label.system = system_name;
     } else if (label.system.value() == "*") {

--- a/src/uenv/settings.cpp
+++ b/src/uenv/settings.cpp
@@ -171,7 +171,11 @@ configuration generate_configuration(const config_base& base) {
 
     // disable color output if it has not be enabled/disabled
     config.color = base.color.value_or(false);
+
+    // set elastic logging end point
     config.elastic_config = base.elastic_config;
+
+    // set the system name
     if (base.system_name) {
         if (parse_cluster_name(base.system_name.value())) {
             config.system_name = base.system_name;
@@ -522,11 +526,13 @@ parse_repository_array(const toml::node& input,
     return result;
 }
 
-util::expected<std::string, config_error>
+util::expected<std::optional<std::string>, config_error>
 parse_system(const toml::node& input) {
     if (const auto v = input.value<std::string>()) {
         if (const auto name = uenv::parse_cluster_name(v.value())) {
-            return name.value();
+            // return the raw representation, which might be "*"
+            // the value will be parsed again during generate_configuration()
+            return v;
         }
     }
 

--- a/test/unit/parse.cpp
+++ b/test/unit/parse.cpp
@@ -506,6 +506,25 @@ TEST_CASE("cluster", "[parse]") {
     REQUIRE(!uenv::parse_cluster_name("alps-daint-ln002"));
 }
 
+TEST_CASE("xthostname", "[parse]") {
+    REQUIRE(uenv::parse_xthostname("eiger").value() == "eiger");
+    REQUIRE(uenv::parse_xthostname("alps-eiger").value() == "eiger");
+    REQUIRE(uenv::parse_xthostname("daint").value() == "daint");
+    REQUIRE(uenv::parse_xthostname("alps-daint").value() == "daint");
+    REQUIRE(uenv::parse_xthostname("  eiger_ln002 ").value() == "eiger_ln002");
+
+    // we do not permit trailing dash or comma in cluster names
+    REQUIRE(!uenv::parse_xthostname("alps-"));
+    REQUIRE(!uenv::parse_xthostname("alps-eiger-"));
+    REQUIRE(!uenv::parse_xthostname("alps,"));
+    // empty names are not permitted
+    REQUIRE(!uenv::parse_xthostname(""));
+
+    // maybe the following should be enabled in the future, i.e. strip alps- and
+    // glob remaining - into the cluster name
+    REQUIRE(!uenv::parse_xthostname("alps-daint-ln002"));
+}
+
 TEST_CASE("repo_name", "[parse]") {
     REQUIRE(uenv::parse_repo_name("repo").value() == "repo");
     REQUIRE(uenv::parse_repo_name("main").value() == "main");

--- a/test/unit/parse.cpp
+++ b/test/unit/parse.cpp
@@ -488,14 +488,17 @@ TEST_CASE("cluster", "[parse]") {
     REQUIRE(uenv::parse_cluster_name("daint").value() == "daint");
     REQUIRE(uenv::parse_cluster_name("  eiger_ln002 ").value() ==
             "eiger_ln002");
-    REQUIRE(uenv::parse_cluster_name("*").value() == "*");
+    // * is a wildcard that means "all", which is represented by an empty
+    // std::optional
+    REQUIRE(uenv::parse_cluster_name("*").value() == std::nullopt);
 
     REQUIRE(!uenv::parse_cluster_name("*wombat"));
 
-    // we do not permit dash in cluster names
+    // we do not permit dash or comma in cluster names
     REQUIRE(!uenv::parse_cluster_name("alps-,"));
     REQUIRE(!uenv::parse_cluster_name("alps,"));
     REQUIRE(!uenv::parse_cluster_name("alps-daint"));
+    // empty names are not permitted
     REQUIRE(!uenv::parse_cluster_name(""));
 
     // maybe the following should be enabled in the future, i.e. strip alps- and

--- a/test/unit/parse.cpp
+++ b/test/unit/parse.cpp
@@ -483,17 +483,19 @@ TEST_CASE("cluster", "[parse]") {
     //
     // the first part of a hyphenated name is dropped, because some CSCS
     // clusters used to be use alps-NAME to name the cluster.
-    REQUIRE(uenv::parse_cluster_name("alps-eiger").value() == "eiger");
-    REQUIRE(uenv::parse_cluster_name("alps-daint").value() == "daint");
+    // REQUIRE(uenv::parse_cluster_name("alps-eiger").value() == "eiger");
     REQUIRE(uenv::parse_cluster_name("eiger").value() == "eiger");
     REQUIRE(uenv::parse_cluster_name("daint").value() == "daint");
-    REQUIRE(uenv::parse_cluster_name("alps-eiger002").value() == "eiger002");
     REQUIRE(uenv::parse_cluster_name("  eiger_ln002 ").value() ==
             "eiger_ln002");
-    REQUIRE(uenv::parse_cluster_name("wombat-soup").value() == "soup");
+    REQUIRE(uenv::parse_cluster_name("*").value() == "*");
 
+    REQUIRE(!uenv::parse_cluster_name("*wombat"));
+
+    // we do not permit dash in cluster names
     REQUIRE(!uenv::parse_cluster_name("alps-,"));
     REQUIRE(!uenv::parse_cluster_name("alps,"));
+    REQUIRE(!uenv::parse_cluster_name("alps-daint"));
     REQUIRE(!uenv::parse_cluster_name(""));
 
     // maybe the following should be enabled in the future, i.e. strip alps- and


### PR DESCRIPTION
- [x] add a custom `parse_xthostname` parser, that special cases parsing names like `alps-daint` to `daint`.